### PR TITLE
Hopefully a fix for a potential bug

### DIFF
--- a/nms-v1_8_R2/src/main/java/net/techcable/npclib/nms/versions/v1_8_R2/NMS.java
+++ b/nms-v1_8_R2/src/main/java/net/techcable/npclib/nms/versions/v1_8_R2/NMS.java
@@ -201,6 +201,8 @@ public class NMS implements net.techcable.npclib.nms.NMS {
 
 	@Override
 	public void onDespawn(NPC npc) {
+  	    WorldServer world = getHandle(npc.getLocation().getWorld());
+            world.removeEntity(getHandle(npc.getEntity()));
             sendPacketsTo(Bukkit.getOnlinePlayers(), new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, getHandle((Player)npc.getEntity())));
 	}
 }

--- a/nms-v1_8_R2/src/main/java/net/techcable/npclib/nms/versions/v1_8_R2/NMS.java
+++ b/nms-v1_8_R2/src/main/java/net/techcable/npclib/nms/versions/v1_8_R2/NMS.java
@@ -201,8 +201,8 @@ public class NMS implements net.techcable.npclib.nms.NMS {
 
 	@Override
 	public void onDespawn(NPC npc) {
-  	    WorldServer world = getHandle(npc.getLocation().getWorld());
-            world.removeEntity(getHandle(npc.getEntity()));
             sendPacketsTo(Bukkit.getOnlinePlayers(), new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, getHandle((Player)npc.getEntity())));
+	    WorldServer world = getHandle(npc.getEntity().getLocation().getWorld());
+            world.removeEntity(getHandle(npc.getEntity()));
 	}
 }


### PR DESCRIPTION
There are a couple things I want to mention here:

1. I added my changes in the github browser editor. So I am not exactly sure if they will compile correctly. I mean the code is solid, but I dont know if the class has all the imports, etc.

2. I'm using a pretty heavily modified version of NPCLib. Its possible I missed something and you are already handling this, but I thought I would do this just in case.

Now on to the actual problem.
I found this while I was making an anti-logger npc system. I was having the problem that I could not unload my worlds. ( using Bukkit.unloadWorld() ) After doing some browsing, It seemed the problem was that the NPC's CraftEntity was not being removed from the CraftWorld. (maybe because its being stored as a player? idk.) This was making it so that the world could not unload correctly. Anyway, I tried this and it worked for me. I thought it might be something you could benefit from, so here it is.

Edit: You would probably have to do the same thing for each NMS implementation, I just forgot to do that.