### PR TITLE
1.9 nms bug fix

### DIFF
--- a/nms-v1_9_R1/src/main/java/net/techcable/npclib/nms/versions/v1_9_R1/LivingNPCHook.java
+++ b/nms-v1_9_R1/src/main/java/net/techcable/npclib/nms/versions/v1_9_R1/LivingNPCHook.java
@@ -44,7 +44,7 @@ public class LivingNPCHook extends NPCHook implements ILivingNPCHook {
         getNmsEntity().aL = yaw; // MCP -- prevRotationYawHead Srg -- field_70758_at
     }
 
-    private final ItemStack[] lastEquipment = new ItemStack[5];
+    private final ItemStack[] lastEquipment = new ItemStack[6];
 
     public static float clampYaw(float yaw) {
         while (yaw < -180.0F) {


### PR DESCRIPTION
enumslots now have 6 elements so, the array which is called lastEquipment has to be 6 elements